### PR TITLE
remove missing Color::LIGHT_ORANGE

### DIFF
--- a/app/Audit/AuditText.php
+++ b/app/Audit/AuditText.php
@@ -118,10 +118,10 @@ class AuditText implements Audit
         $float_score = (float) $score;
         switch (true) {
             case ($float_score >= 9):
-                echo "\t", Color::LIGHT_RED, $text, Color::RESET, PHP_EOL;
+                echo "\t", Color::RED, $text, Color::RESET, PHP_EOL;
             break;
             case ($float_score >= 7 && $float_score < 9):
-                echo "\t", Color::LIGHT_ORANGE, $text, Color::RESET, PHP_EOL;
+                echo "\t", Color::LIGHT_RED, $text, Color::RESET, PHP_EOL;
             break;
             case ($float_score >= 4 && $float_score < 7):
                 echo "\t", Color::LIGHT_YELLOW, $text, Color::RESET, PHP_EOL;


### PR DESCRIPTION
Orange is not a default ANSI code, then not available as a constant in Color