### PR TITLE
Chunk up coordinates, make multiple calls

### DIFF
--- a/app/OSSIndex/OSSIndex.php
+++ b/app/OSSIndex/OSSIndex.php
@@ -37,9 +37,13 @@ class OSSIndex
             $vulnerabilities = array();
 
             foreach($coord_chunks as $chunk) {
+                $chonk = (object)[];
+                $chonk->coordinates = $chunk;
+
                 $response = $this->client->post('v3/component-report', [
-                    RequestOptions::JSON => $coordinates
+                    RequestOptions::JSON => $chonk
                 ]);
+                
                 $code = $response->getStatusCode();
                 if ($code != 200)
                 {

--- a/app/OSSIndex/OSSIndex.php
+++ b/app/OSSIndex/OSSIndex.php
@@ -33,22 +33,26 @@ class OSSIndex
     {
         try
         {
-            $response = $this->client->post('v3/component-report', [
-                RequestOptions::JSON => $coordinates
-            ]);
-            $code = $response->getStatusCode();
-            if ($code != 200)
-            {
-                echo "HTTP request did not return 200 OK: " . $code . ".";
-                return;
-    
+            $coord_chunks = array_chunk($coordinates["coordinates"], 128);
+            $vulnerabilities = array();
+
+            foreach($coord_chunks as $chunk) {
+                $response = $this->client->post('v3/component-report', [
+                    RequestOptions::JSON => $coordinates
+                ]);
+                $code = $response->getStatusCode();
+                if ($code != 200)
+                {
+                    echo "HTTP request did not return 200 OK: " . $code . ".";
+                    return;
+                }
+                else
+                {
+                    $vulnerabilities = array_merge($vulnerabilities, \json_decode($response->getBody(), true));
+                }    
             }
-            else
-            {
-                echo $response->getBody();
-                $vulnerabilities = \json_decode($response->getBody(), true);
-                return $vulnerabilities;
-            }    
+
+            return $vulnerabilities;
         }
         catch (Exception $e)
         {

--- a/tests/OSSIndex/OSSIndexTest.php
+++ b/tests/OSSIndex/OSSIndexTest.php
@@ -23,7 +23,10 @@ class OSSIndexTest extends TestCase
 
         $oss_index = new OSSIndex($client);
 
-        $vulns = $oss_index->get_vulns([]);
+        $coordinates = (object)[];
+        $coordinates->coordinates = ['pkg:test/pkga@1.0.0'];
+
+        $vulns = $oss_index->get_vulns($coordinates);
 
         $this->assertEquals(count($vulns), 60);
     }

--- a/tests/OSSIndex/OSSIndexTest.php
+++ b/tests/OSSIndex/OSSIndexTest.php
@@ -23,8 +23,7 @@ class OSSIndexTest extends TestCase
 
         $oss_index = new OSSIndex($client);
 
-        $coordinates = (object)[];
-        $coordinates->coordinates = ['pkg:test/pkga@1.0.0'];
+        $coordinates["coordinates"] = ['pkg:test/pkga@1.0.0'];
 
         $vulns = $oss_index->get_vulns($coordinates);
 


### PR DESCRIPTION
This SHOULD fix #15 

This chunks up the coordinates into 128 purl chunks, and then calls OSS Index for each chunk, merging the results and returning them!

Not tested super wildly, would love for someone to give it a shot, who has a larger PHP project to test on!