### PR TITLE
fixed composer requirement for php version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,8 @@
         "source": "https://github.com/OSSIndex/bach"
     },
     "require": {
-        "php": ">=7.1.3 || <9.0",
+        "php": "^7.1.3 || ^8.0",
+        "codedungeon/php-cli-colors": "^1.11.0",
         "eloquent/composer-config-reader": "^2.1",
         "guzzlehttp/guzzle": "6.3.3",
         "hoa/console": "^3.17",
@@ -17,8 +18,7 @@
         "laravel-zero/framework": ">=5.8 || <9.0",
         "nadar/php-composer-reader": "^1.2",
         "vierbergenlars/php-semver": "^3.0",
-        "zendframework/zend-text": "^2.7",
-        "codedungeon/php-cli-colors": "^1.11.0"
+        "zendframework/zend-text": "^2.7"
     },
     "require-dev": {
         "mockery/mockery": "^1.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "6ba10a681c984b13b33dedbba906c5f1",
+    "content-hash": "465c3a21954737c9dbd27937ec04123b",
     "packages": [
         {
             "name": "brick/math",
@@ -7404,7 +7404,7 @@
     "prefer-stable": true,
     "prefer-lowest": false,
     "platform": {
-        "php": "^8.0"
+        "php": "^7.1.3 || ^8.0"
     },
     "platform-dev": [],
     "plugin-api-version": "2.0.0"


### PR DESCRIPTION
closes #22

ran `composer require 'php:^7.1.3 || ^8.0'` to generate this patch