### PR TITLE
FIX: Respect composer.lock file as pointed out by Jan Kowalleck.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,9 +31,6 @@ jobs:
             - composer<< parameters.cv >>-{{ checksum "composer.lock" }}
             - composer<< parameters.cv >>-
       - run:
-          name: "Update Composer"
-          command: COMPOSER_MEMORY_LIMIT=-1 composer update
-      - run:
           name: "Composer install"
           command: composer install -n --prefer-dist
       - save_cache:


### PR DESCRIPTION
As pointed out by @jkowalleck on https://github.com/sonatype-nexus-community/bach/pull/36, we are not respecting the `composer.lock` file - this should fix this.